### PR TITLE
croppic.js

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -20,6 +20,7 @@
 			cropUrl:'',
 			cropData:{},
 			outputUrlId:'',
+			imgUrlInit: null,
 			//styles
 			imgEyecandy:true,
 			imgEyecandyOpacity:0.2,
@@ -42,6 +43,15 @@
 
 		// INIT THE WHOLE DAMN THING!!!
 		that.init();
+		
+		// INIT WITH AN IMAGE ON PLUGIN
+		if(that.options.imgUrlInit){
+			that.destroy();
+			that.obj.append('<img class="croppedImg" src="'+that.options.imgUrlInit+'">');
+			$('#'+that.options.outputUrlId).val(that.options.imgUrlInit);
+			that.croppedImg = that.obj.find('.croppedImg');
+			that.init();
+		}
 		
 	};
 


### PR DESCRIPTION
was added the option to load the script with an image already.

In use:
var croppicContaineroutputOptions = {
				uploadUrl:'img_save_to_file.php',
				cropUrl:'img_crop_to_file.php',
				modal:false,
				imgEyecandyOpacity:0,
				imgUrlInit: 'assets/images/exemple.jpg',
				loaderHtml:'<div class="loader bubblingG"><span id="bubblingG_1"></span><span id="bubblingG_2"></span><span id="bubblingG_3"></span></div> '
		}
		var cropContaineroutput = new Croppic('croppic', croppicContaineroutputOptions);