### PR TITLE
Update croppic.js

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -403,6 +403,7 @@
 		},
 		crop:function(){
 			var that = this;
+			that.imgEyecandy = that.img.clone();
 			
 			if (that.options.onBeforeImgCrop) that.options.onBeforeImgCrop.call(that);
 			


### PR DESCRIPTION
First of all, thanks for your croppic plugin, it is awesome!!! 

However while I was trying to make it work with jquery 2.1.1+jquery-migrate-1.2.1 and I've detected one problem in the Eye Candy sample (the other samples works like a charm ;)) 
In the Eye Candy sample, after the image is selected, when you push the crop button, the Firefox browser raises the following javascript error (located at line 450 of croppic.js): 

TypeError: o.imgEyecandy.hide is not a function

To solve it I've just added the following line at line 406 position:

that.imgEyecandy = that.img.clone(); 

Please review the pull request and if you consider it right merge it with your code.

Cheers,

Eduardo Crespo