### PR TITLE
Fixed croppic behaviour when cropped image is smaller than cropping area

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -447,9 +447,7 @@
 					response = jQuery.parseJSON(data);
 					if(response.status=='success'){
 						
-						if (that.options.imgEyecandy){
-							that.imgEyecandy.hide();
-						}
+						that.imgEyecandy.hide();
 						
 						that.destroy();
 						

--- a/croppic.js
+++ b/croppic.js
@@ -447,7 +447,9 @@
 					response = jQuery.parseJSON(data);
 					if(response.status=='success'){
 						
-						that.imgEyecandy.hide();
+						if (that.options.imgEyecandy){
+							that.imgEyecandy.hide();
+						}
 						
 						that.destroy();
 						

--- a/croppic.js
+++ b/croppic.js
@@ -319,11 +319,21 @@
 					
 					if(that.options.imgEyecandy){ that.imgEyecandy.offset({ top:imgTop, left:imgLeft }); }
 					
-					if( parseInt( that.img.css('top')) > 0 ){ that.img.css('top',0);  if(that.options.imgEyecandy){ that.imgEyecandy.css('top', 0); } }
-					var maxTop = -( that.imgH-that.objH); if( parseInt( that.img.css('top')) < maxTop){ that.img.css('top', maxTop); if(that.options.imgEyecandy){ that.imgEyecandy.css('top', maxTop); } }
-					
-					if( parseInt( that.img.css('left')) > 0 ){ that.img.css('left',0); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', 0); }}
-					var maxLeft = -( that.imgW-that.objW); if( parseInt( that.img.css('left')) < maxLeft){ that.img.css('left', maxLeft); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', maxLeft); } }
+					if (that.objH < that.imgH) {
+						if (parseInt(that.img.css('top')) > 0) { that.img.css('top', 0); if (that.options.imgEyecandy) { that.imgEyecandy.css('top', 0);}}
+						var maxTop = -( that.imgH - that.objH); if (parseInt(that.img.css('top')) < maxTop) { that.img.css('top', maxTop); if (that.options.imgEyecandy) { that.imgEyecandy.css('top', maxTop); }}
+					}else{
+						if (parseInt(that.img.css('top')) < 0) { that.img.css('top', 0); if (that.options.imgEyecandy) { that.imgEyecandy.css('top', 0); }}
+						var maxTop =  that.objH - that.imgH; if (parseInt(that.img.css('top')) > maxTop) { that.img.css('top', maxTop);if (that.options.imgEyecandy) {that.imgEyecandy.css('top', maxTop); }}
+					}
+
+					if (that.objW < that.imgW) {
+						if( parseInt( that.img.css('left')) > 0 ){ that.img.css('left',0); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', 0); }}
+						var maxLeft = -( that.imgW-that.objW); if( parseInt( that.img.css('left')) < maxLeft){ that.img.css('left', maxLeft); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', maxLeft); } }
+					}else{
+						if( parseInt( that.img.css('left')) < 0 ){ that.img.css('left',0); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', 0); }}
+						var maxLeft = ( that.objW - that.imgW); if( parseInt( that.img.css('left')) > maxLeft){ that.img.css('left', maxLeft); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', maxLeft); } }
+					}
 					
 					if (that.options.onImgDrag) that.options.onImgDrag.call(that);
 					

--- a/croppic.js
+++ b/croppic.js
@@ -34,7 +34,8 @@
 			onImgDrag: null,
 			onImgZoom: null,
 			onBeforeImgCrop: null,
-			onAfterImgCrop: null
+			onAfterImgCrop: null,
+			scaleToFill: true
 		};
 
 		// OVERWRITE DEFAULT OPTIONS
@@ -334,7 +335,7 @@
 						if( parseInt( that.img.css('left')) < 0 ){ that.img.css('left',0); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', 0); }}
 						var maxLeft = ( that.objW - that.imgW); if( parseInt( that.img.css('left')) > maxLeft){ that.img.css('left', maxLeft); if(that.options.imgEyecandy){ that.imgEyecandy.css('left', maxLeft); } }
 					}
-					
+
 					if (that.options.onImgDrag) that.options.onImgDrag.call(that);
 					
 				});
@@ -367,7 +368,7 @@
 				
 			} 
 			
-			if( newWidth > that.imgInitW || newHeight > that.imgInitH){
+			if(!that.options.scaleToFill && (newWidth > that.imgInitW || newHeight > that.imgInitH)){
 				
 				if( newWidth - that.imgInitW < newHeight - that.imgInitH ){ 
 					newWidth = that.imgInitW;


### PR DESCRIPTION
When cropped image was smaller than cropping area, the dragging didn't work. Now the dragging works as expected.

Also I added new option scaleToFill which defaults to true. This will enlarge any smaller image to the crop area.