### PR TITLE
Support for abandoned files

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -20,6 +20,7 @@
 			cropUrl:'',
 			cropData:{},
 			outputUrlId:'',
+			deleteUrl:'',
 			//styles
 			imgEyecandy:true,
 			imgEyecandyOpacity:0.2,
@@ -155,6 +156,7 @@
 					
 					that.croppedImg.remove();
 					$(this).hide();
+					that.delete(that.cropUrl);
 					
 					if (typeof (that.options.onAfterRemoveCroppedImg) === typeof(Function)) {
 						that.options.onAfterRemoveCroppedImg.call(that);
@@ -412,7 +414,10 @@
 			that.cropControlCrop.on('click',function(){ that.crop(); });
 
 			that.cropControlReset = that.cropControlsCrop.find('.cropControlReset');
-			that.cropControlReset.on('click',function(){ that.reset(); });				
+			that.cropControlReset.on('click',function(){ 
+				that.delete(that.imgUrl);
+				that.reset();
+			});				
 			
 		},
 		initDrag:function(){
@@ -621,6 +626,7 @@
 						    that.imgEyecandy.hide();
 						
 						that.destroy();
+						that.cropUrl=response.url;
 						
 						that.obj.append('<img class="croppedImg" src="'+response.url+'">');
 						if(that.options.outputUrlId !== ''){	$('#'+that.options.outputUrlId).val(response.url);	}
@@ -675,6 +681,51 @@
 			if( !$.isEmptyObject( that.loader ) ){   that.loader.remove(); }
 			if( !$.isEmptyObject( that.form ) ){   that.form.remove(); }
 			that.obj.html('');
-		}
+		},
+                
+                delete: function (myURL) {
+                    var that = this;
+                    
+                    var deleteData = {
+                    deleteUrl:myURL
+                    };
+
+                    var formData = new FormData();
+
+                    for (var key in deleteData) {
+                            if( deleteData.hasOwnProperty(key) ) {
+                                            formData.append( key , deleteData[key] );
+                            }
+                    }
+
+                    $.ajax({
+                        url: that.options.deleteUrl,
+                        data: formData,
+                        context: document.body,
+                        cache: false,
+                        contentType: false,
+                        processData: false,
+                        type: 'POST'
+                    }).always(function(data) {
+                        response = typeof data == 'object' ? data : jQuery.parseJSON(data);
+
+                        if (response.status == 'success') {
+
+                            //add code if desired
+
+                        }
+
+                        if (response.status == 'error') {
+                            if (that.options.onError)
+                                that.options.onError.call(that, response.message);
+                            that.hideLoader();
+                            setTimeout(function() {
+                                that.reset();
+                            }, 2000)
+                        }
+
+                    });
+				
+		}    
 	};
 })(window, document);

--- a/img_delete_file.php
+++ b/img_delete_file.php
@@ -1,0 +1,19 @@
+<?php
+/*
+*	!!! THIS IS JUST AN EXAMPLE !!!
+*/
+$deleteUrl = $_POST['deleteUrl'];
+
+// delete the cropped file
+unlink ($deleteUrl);
+
+if (!file_exists ($deleteUrl)) {
+    $response = Array(
+	    "status" => 'success',
+        );
+} else {
+    $response = Array(
+	    "status" => 'error',
+        );
+}
+print json_encode($response);


### PR DESCRIPTION
The Upload URL and Crop URL processing files are perfect for processing uploaded and cropped files as required.  However, there is no support for files which are abandoned by a user in either the uploaded or cropped stages.  These can of course be removed manually or by a CRON job...  but why not add functionality here to deal with them before they pile up and to eliminate the possibility of manual removal or a CRON job from interfering with a user.  

I added such functionality to the croppic.js and made a sample processing file.  I modeled the code on the existing code to facilitate additions if needed.