### PR TITLE
Allow setting custom headers on upload and crop requests

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -218,6 +218,7 @@
 						url: that.options.uploadUrl,
 						data: formData,
 						context: document.body,
+						headers: that.options.uploadHeaders,
 						cache: false,
 						contentType: false,
 						processData: false,
@@ -608,6 +609,7 @@
 			$.ajax({
                 url: that.options.cropUrl,
                 data: formData,
+                headers: that.options.cropHeaders,
                 context: document.body,
                 cache: false,
                 contentType: false,


### PR DESCRIPTION
Useful for adding things like CSRF tokens, etc.
