### PR TITLE
Add xhr response data to onAfterImgCrop, so we can do things client side

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -703,7 +703,7 @@
 				setTimeout( function(){ that.reset(); },2000)	
             }
 
-            if (that.options.onAfterImgCrop) that.options.onAfterImgCrop.call(that);
+            if (that.options.onAfterImgCrop) that.options.onAfterImgCrop.call(that, response);
         },
 		showLoader:function(){
 			var that = this;


### PR DESCRIPTION
To allow for better user experience, we want to perform extra interactions after the onAfterImgCrop. By passing the response data to the callback, we can pass extra data from the server to the client related to the crop, like image ids, etc.