### PR TITLE
Reset in odd state after deleting cropped image

### DIFF
--- a/croppic.js
+++ b/croppic.js
@@ -165,6 +165,7 @@
 					}
 					
 					that.croppedImg.remove();
+					that.croppedImg = {};
 					$(this).hide();
 					
 					if (typeof (that.options.onAfterRemoveCroppedImg) === typeof(Function)) {


### PR DESCRIPTION
If you upload an image with croppic, crop the image, hit remove, upload a new image, then his the reset button, your previously removed cropped image will pop up.

This appears to be the case because although we removed the `croppedImg` from the DOM, we didn't remove it form the croppic object.